### PR TITLE
Add compatibility with podman

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -2,4 +2,4 @@
     name: Pyspelling in docker
     description: Pyspelling with aspell using Dockerfile of github action, based on https://github.com/rojopolis/spellcheck-github-actions
     language: docker_image
-    entry: jonasbn/github-action-spellcheck:latest
+    entry: docker.io/jonasbn/github-action-spellcheck:latest


### PR DESCRIPTION
The prefix is needed for podman and compatible with docker
---
btw. it also didn't work until I added this snippet to `$HOME/.config/containers/containers.conf`
```
[containers]
userns="keep-id"
```
not sure how to document this...